### PR TITLE
Schedule daily case checks

### DIFF
--- a/lib/modules/case/controllers/case_controller.dart
+++ b/lib/modules/case/controllers/case_controller.dart
@@ -111,7 +111,7 @@ class CaseController extends GetxController {
         cases.value = event;
         isLoading.value = false;
         _scheduleTomorrowNotification();
-        _scheduleOverdueNotificationsEvery3Hours();
+        _scheduleOverdueNotification();
         if (_enable3MinTestNoti) _start3MinTestNotifications();
       });
     } else {
@@ -160,14 +160,14 @@ class CaseController extends GetxController {
     }
   }
 
-  Future<void> _scheduleOverdueNotificationsEvery3Hours() async {
+  Future<void> _scheduleOverdueNotification() async {
     // Clean up legacy every-3-hours notifications (from older builds)
     const oldHours = [0, 3, 6, 9, 12, 15, 18, 21];
     for (final h in oldHours) {
       await _localNoti.cancel(300 + h);
     }
 
-    // Daily at 11 PM BD time — only if there are overdue cases
+    // Daily at 12 AM BD time — only if there are overdue cases
     final count = overdueCases.length;
     if (count > 0) {
       final title = 'ওভারডিউ কেসের আপডেট';
@@ -176,7 +176,7 @@ class CaseController extends GetxController {
         id: 310,
         title: title,
         body: body,
-        hour: 23,
+        hour: 0,
         minute: 0,
         payload: 'overdue_cases',
       );


### PR DESCRIPTION
## Summary
- run background worker at 4 PM for tomorrow-case alerts and at midnight for overdue cases
- show notifications only when there are matching cases
- align in-app scheduling with midnight overdue notification

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b1f5f50c8330b1fedc580e924a7d