### PR TITLE
Schedule overdue case checks at noon

### DIFF
--- a/lib/modules/case/controllers/case_controller.dart
+++ b/lib/modules/case/controllers/case_controller.dart
@@ -167,7 +167,7 @@ class CaseController extends GetxController {
       await _localNoti.cancel(300 + h);
     }
 
-    // Daily at 12 AM BD time — only if there are overdue cases
+    // Daily at 12 PM BD time — only if there are overdue cases
     final count = overdueCases.length;
     if (count > 0) {
       final title = 'ওভারডিউ কেসের আপডেট';
@@ -176,7 +176,7 @@ class CaseController extends GetxController {
         id: 310,
         title: title,
         body: body,
-        hour: 0,
+        hour: 12,
         minute: 0,
         payload: 'overdue_cases',
       );

--- a/lib/services/workmanager_service.dart
+++ b/lib/services/workmanager_service.dart
@@ -103,11 +103,11 @@ class WorkManagerService {
       existingWorkPolicy: ExistingWorkPolicy.keep,
     );
 
-    // Next midnight for overdue-case checks
-    final nextMidnight = DateTime(now.year, now.month, now.day).add(
-      const Duration(days: 1),
-    );
-    final overdueDelay = nextMidnight.difference(now);
+    // Next 12 PM for overdue-case checks
+    final nextNoon = DateTime(now.year, now.month, now.day, 12);
+    final overdueDelay = nextNoon.isBefore(now)
+        ? nextNoon.add(const Duration(days: 1)).difference(now)
+        : nextNoon.difference(now);
     await Workmanager().registerPeriodicTask(
       overdueCaseCheckTask,
       overdueCaseCheckTask,


### PR DESCRIPTION
## Summary
- run overdue case worker at noon instead of midnight
- notify overdue cases daily at noon

## Testing
- `dart format lib/services/workmanager_service.dart lib/modules/case/controllers/case_controller.dart` (fails: command not found)
- `flutter format lib/services/workmanager_service.dart lib/modules/case/controllers/case_controller.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1cfedb0e88330bb78568f77fde80e