### PR TITLE
Add optional biometric lock with local auth toggle

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -40,7 +40,8 @@ android {
         applicationId = "com.appseba.courtdiary"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        // local_auth requires at least SDK 23
+        minSdk = 23
         // Target the latest stable Android API level (Android 15)
         targetSdk = 35
         versionCode = flutter.versionCode

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <!-- Allow background work to continue after device reboot -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- Biometric authentication -->
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <application
         android:label="Court Dairy"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,9 +43,11 @@
 		</array>
 		<key>CADisableMinimumFrameDurationOnPhone</key>
 		<true/>
-		<key>UIApplicationSupportsIndirectInputEvents</key>
-		<true/>
-		<key>UIStatusBarHidden</key>
-		<false/>
-	</dict>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>UIStatusBarHidden</key>
+        <false/>
+        <key>NSFaceIDUsageDescription</key>
+        <string>Use Face ID to secure your account</string>
+       </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'modules/auth/controllers/auth_controller.dart';
+import 'modules/auth/controllers/local_auth_controller.dart';
 import 'modules/auth/screens/auth_view.dart';
 import 'modules/layout/screens/layout_screen.dart';
 import 'navigation/app_transitions.dart';
@@ -97,8 +98,14 @@ class _AuthGate extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final auth = Get.find<AuthController>();
+    final localAuth = Get.find<LocalAuthController>();
     return Obx(() {
       if (auth.user.value != null) {
+        if (localAuth.isEnabled.value && !localAuth.isAuthenticated.value) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
         return LayoutScreen();
       } else {
         return const AuthScreen();

--- a/lib/modules/auth/controllers/local_auth_controller.dart
+++ b/lib/modules/auth/controllers/local_auth_controller.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:get/get.dart';
+import '../services/local_auth_service.dart';
+
+class LocalAuthController extends GetxController with WidgetsBindingObserver {
+  final isEnabled = false.obs;
+  final isAuthenticated = true.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    WidgetsBinding.instance.addObserver(this);
+    isEnabled.value = LocalAuthService.isEnabled();
+    if (isEnabled.value) {
+      lock();
+    }
+  }
+
+  @override
+  void onClose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.onClose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed && isEnabled.value) {
+      lock();
+    }
+  }
+
+  Future<void> toggle(bool value) async {
+    if (value) {
+      final success = await LocalAuthService.authenticate();
+      if (!success) return;
+    }
+    isEnabled.value = value;
+    await LocalAuthService.setEnabled(value);
+    if (value) {
+      lock();
+    }
+  }
+
+  void lock() {
+    isAuthenticated.value = false;
+    authenticate();
+  }
+
+  Future<void> authenticate() async {
+    final didAuth = await LocalAuthService.authenticate();
+    isAuthenticated.value = didAuth;
+    if (!didAuth) {
+      SystemNavigator.pop();
+    }
+  }
+}

--- a/lib/modules/auth/services/local_auth_service.dart
+++ b/lib/modules/auth/services/local_auth_service.dart
@@ -1,0 +1,31 @@
+import 'package:local_auth/local_auth.dart';
+import '../../../services/local_storage.dart';
+
+class LocalAuthService {
+  static final LocalAuthentication _auth = LocalAuthentication();
+  static const _key = 'local_auth_enabled';
+
+  static bool isEnabled() {
+    return LocalStorageService.read(_key) ?? false;
+  }
+
+  static Future<void> setEnabled(bool value) async {
+    LocalStorageService.write(_key, value);
+  }
+
+  static Future<bool> authenticate() async {
+    try {
+      final canCheck = await _auth.isDeviceSupported() || await _auth.canCheckBiometrics;
+      if (!canCheck) return false;
+      return await _auth.authenticate(
+        localizedReason: 'Please authenticate to continue',
+        options: const AuthenticationOptions(
+          stickyAuth: true,
+          biometricOnly: false,
+        ),
+      );
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/modules/layout/widgets/app_drawer.dart
+++ b/lib/modules/layout/widgets/app_drawer.dart
@@ -5,6 +5,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import '../../auth/controllers/auth_controller.dart';
+import '../../auth/controllers/local_auth_controller.dart';
 import '../../court_dairy/screens/account_reset_screen.dart';
 import '../controllers/layout_controller.dart';
 
@@ -13,6 +14,7 @@ class AppDrawer extends StatelessWidget {
 
   final layoutController = Get.find<LayoutController>();
   final authController = Get.find<AuthController>();
+  final localAuthController = Get.find<LocalAuthController>();
 
   @override
   Widget build(BuildContext context) {
@@ -194,27 +196,23 @@ class AppDrawer extends StatelessWidget {
 
                   const SizedBox(height: 36),
 
-                  // // অ্যাপ সেটিংস Section
-                  // _sectionHeader(context, 'অ্যাপ সেটিংস'),
-                  // const SizedBox(height: 8),
-                  // _infoTile(
-                  //   context,
-                  //   icon: Icons.brightness_6_rounded,
-                  //   title: 'থিম পরিবর্তন',
-                  //   subtitle: theme.brightness == Brightness.dark
-                  //       ? 'ডার্ক মোড'
-                  //       : 'লাইট মোড',
-                  //   onTap: () => Get.find<ThemeController>().toggleTheme(),
-                  //   trailing: Obx(() {
-                  //     final isDark = Get.find<ThemeController>().isDarkMode;
-                  //     return Switch.adaptive(
-                  //       value: isDark,
-                  //       onChanged: (_) =>
-                  //           Get.find<ThemeController>().toggleTheme(),
-                  //     );
-                  //   }),
-                  // ),
-                  // const SizedBox(height: 36),
+                  _sectionHeader(context, 'অ্যাপ সেটিংস'),
+                  const SizedBox(height: 8),
+                  Obx(() {
+                    final enabled = localAuthController.isEnabled.value;
+                    return _infoTile(
+                      context,
+                      icon: Icons.fingerprint,
+                      title: 'লোকাল অথেন্টিকেশন',
+                      subtitle: enabled ? 'চালু' : 'বন্ধ',
+                      trailing: Switch.adaptive(
+                        value: enabled,
+                        onChanged: (v) => localAuthController.toggle(v),
+                      ),
+                    );
+                  }),
+
+                  const SizedBox(height: 36),
 
                   // সাবস্ক্রিপশন বিস্তারিত Section
                   _sectionHeader(context, 'সাবস্ক্রিপশন বিস্তারিত'),

--- a/lib/services/initial_bindings.dart
+++ b/lib/services/initial_bindings.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import '../modules/auth/controllers/auth_controller.dart';
+import '../modules/auth/controllers/local_auth_controller.dart';
 import '../modules/layout/controllers/layout_controller.dart';
 
 class InitialBindings extends Bindings {
@@ -7,5 +8,6 @@ class InitialBindings extends Bindings {
   void dependencies() {
     Get.put(AuthController());
     Get.put(LayoutController());
+    Get.put(LocalAuthController());
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ dependencies:
   android_intent_plus: ^5.3.1
   dotted_border: ^2.1.0
   workmanager: ^0.6.0
+  local_auth: ^2.1.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add local auth service and controller to manage biometric lock
- expose toggle in app drawer and gate main screen on authentication
- configure Android/iOS for biometrics and bump min SDK

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d7a84b84833086b0ebdc43d6b0e5