### PR TITLE
Revamp dashboard account cards with icons and gradients

### DIFF
--- a/lib/modules/layout/widgets/accounts_card.dart
+++ b/lib/modules/layout/widgets/accounts_card.dart
@@ -1,41 +1,117 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:intl/intl.dart';
+
 import '../../../themes/theme_controller.dart';
 
 class AccountsCard extends StatelessWidget {
+  AccountsCard({
+    super.key,
+    required this.title,
+    required this.amount,
+    required this.icon,
+    this.gradientColors,
+    this.iconBackgroundColor,
+    this.iconColor,
+    this.width,
+  });
+
   final String title;
   final double amount;
+  final IconData icon;
+  final List<Color>? gradientColors;
+  final Color? iconBackgroundColor;
+  final Color? iconColor;
+  final double? width;
 
-  AccountsCard({super.key, required this.title, required this.amount});
   final themeController = Get.find<ThemeController>();
+
+  static const List<Color> _defaultGradientDark = [
+    Color(0xFF0F172A),
+    Color(0xFF1E293B),
+  ];
+
+  static const List<Color> _defaultGradientLight = [
+    Color(0xFF93C5FD),
+    Color(0xFF60A5FA),
+  ];
 
   @override
   Widget build(BuildContext context) {
+    final isDarkMode = themeController.isDarkMode;
+    final cardWidth = width ?? (MediaQuery.of(context).size.width * 0.3);
+    final colors = gradientColors ??
+        (isDarkMode ? _defaultGradientDark : _defaultGradientLight);
+    final Color foregroundColor = iconColor ?? Colors.white;
+    final Color badgeColor = iconBackgroundColor ??
+        Colors.white.withOpacity(isDarkMode ? 0.14 : 0.24);
+    final numberFormat = NumberFormat.currency(
+      locale: 'bn_BD',
+      symbol: '',
+      decimalDigits: 0,
+    );
+
     return SizedBox(
-      width: Get.width * 0.3,
-      child: Material(
-        elevation: 0.1,
-        borderRadius: BorderRadius.circular(7),
-        color: themeController.isDarkMode ? Colors.grey[900] : Colors.white,
+      width: cardWidth,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: colors,
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: Colors.white.withOpacity(isDarkMode ? 0.04 : 0.12),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: colors.last.withOpacity(isDarkMode ? 0.45 : 0.25),
+              blurRadius: 22,
+              offset: const Offset(0, 12),
+            ),
+          ],
+        ),
         child: Padding(
-          padding: const EdgeInsets.all(3.0),
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
           child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(title),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: badgeColor,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  icon,
+                  size: 26,
+                  color: foregroundColor,
+                ),
+              ),
+              const SizedBox(height: 18),
+              Text(
+                title,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Colors.white.withOpacity(0.85),
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+              const SizedBox(height: 6),
               TweenAnimationBuilder<int>(
                 tween: IntTween(
                   begin: 0,
                   end: amount.floor(),
-                ), // Count up to endValue
-                duration: const Duration(seconds: 1),
+                ),
+                duration: const Duration(milliseconds: 900),
                 builder: (context, value, child) {
                   return Text(
-                    NumberFormat.currency(
-                      locale: 'bn_BD',
-                      symbol: '',
-                      decimalDigits: 0,
-                    ).format(value).trim(), // Format the number as currency
+                    numberFormat.format(value).trim(),
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
                   );
                 },
               ),

--- a/lib/modules/layout/widgets/accounts_first_card.dart
+++ b/lib/modules/layout/widgets/accounts_first_card.dart
@@ -7,55 +7,112 @@ import 'accounts_card.dart';
 class AccountsFirstCard extends StatelessWidget {
   const AccountsFirstCard({super.key});
 
+  static const _gradients = [
+    [Color(0xFF12324B), Color(0xFF0A192F)],
+    [Color(0xFF1E1B4B), Color(0xFF312E81)],
+    [Color(0xFF134E4A), Color(0xFF0F2A2C)],
+    [Color(0xFF1E293B), Color(0xFF0F172A)],
+    [Color(0xFF0F3F5B), Color(0xFF082032)],
+    [Color(0xFF2D1B69), Color(0xFF1B103F)],
+  ];
+
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final caseController = Get.find<CaseController>();
 
-    return Obx(() {
-      final cases = caseController.cases;
-      final running =
-          cases.where((c) => c.caseStatus.toLowerCase() == 'ongoing').length.toDouble();
-      final closed =
-          cases.where((c) => c.caseStatus.toLowerCase() == 'disposed').length.toDouble();
-      final complicated =
-          cases.where((c) => c.caseStatus.toLowerCase() == 'completed').length.toDouble();
-      final totalCases = cases.length.toDouble();
-      final threeMonthsAgo = DateTime.now().subtract(const Duration(days: 90));
-      final newCases = cases
-          .where((c) => c.filedDate.toDate().isAfter(threeMonthsAgo))
-          .length
-          .toDouble();
-      final totalCourts =
-          cases.map((c) => c.courtName).toSet().length.toDouble();
+    return Material(
+      color: cs.surface,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            const spacing = 16.0;
+            final width = constraints.maxWidth;
+            final crossAxisCount = width >= 900
+                ? 3
+                : width >= 520
+                    ? 2
+                    : 1;
+            final availableWidth =
+                width - spacing * (crossAxisCount - 1);
+            final cardWidth = availableWidth / crossAxisCount;
 
-      return Material(
-        color: cs.surface,
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: Column(
-            spacing: 5,
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            return Obx(() {
+              final cases = caseController.cases;
+              final running = cases
+                  .where((c) => c.caseStatus.toLowerCase() == 'ongoing')
+                  .length
+                  .toDouble();
+              final closed = cases
+                  .where((c) => c.caseStatus.toLowerCase() == 'disposed')
+                  .length
+                  .toDouble();
+              final complicated = cases
+                  .where((c) => c.caseStatus.toLowerCase() == 'completed')
+                  .length
+                  .toDouble();
+              final totalCases = cases.length.toDouble();
+              final threeMonthsAgo = DateTime.now().subtract(const Duration(days: 90));
+              final newCases = cases
+                  .where((c) => c.filedDate.toDate().isAfter(threeMonthsAgo))
+                  .length
+                  .toDouble();
+              final totalCourts =
+                  cases.map((c) => c.courtName).toSet().length.toDouble();
+
+              return Wrap(
+                spacing: spacing,
+                runSpacing: spacing,
                 children: [
-                  AccountsCard(title: 'চলমান কেস', amount: running),
-                  AccountsCard(title: 'বন্ধ কেস', amount: closed),
-                  AccountsCard(title: 'কমপ্লিট কেস', amount: complicated),
+                  AccountsCard(
+                    title: 'চলমান কেস',
+                    amount: running,
+                    icon: Icons.gavel_rounded,
+                    gradientColors: _gradients[0],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'বন্ধ কেস',
+                    amount: closed,
+                    icon: Icons.lock_outline,
+                    gradientColors: _gradients[1],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'কমপ্লিট কেস',
+                    amount: complicated,
+                    icon: Icons.verified,
+                    gradientColors: _gradients[2],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'মোট কেস',
+                    amount: totalCases,
+                    icon: Icons.all_inbox,
+                    gradientColors: _gradients[3],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'নতুন কেস',
+                    amount: newCases,
+                    icon: Icons.fiber_new,
+                    gradientColors: _gradients[4],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'মোট কোর্ট',
+                    amount: totalCourts,
+                    icon: Icons.account_balance,
+                    gradientColors: _gradients[5],
+                    width: cardWidth,
+                  ),
                 ],
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  AccountsCard(title: 'মোট কেস', amount: totalCases),
-                  AccountsCard(title: 'নতুন কেস', amount: newCases),
-                  AccountsCard(title: 'মোট কোর্ট', amount: totalCourts),
-                ],
-              ),
-            ],
-          ),
+              );
+            });
+          },
         ),
-      );
-    });
+      ),
+    );
   }
 }

--- a/lib/modules/layout/widgets/accounts_second_card.dart
+++ b/lib/modules/layout/widgets/accounts_second_card.dart
@@ -8,6 +8,15 @@ import 'accounts_card.dart';
 class AccountsSecondCard extends StatelessWidget {
   const AccountsSecondCard({super.key});
 
+  static const _gradients = [
+    [Color(0xFF103B5C), Color(0xFF061A2E)],
+    [Color(0xFF14532D), Color(0xFF0B2A1A)],
+    [Color(0xFF5B21B6), Color(0xFF312E81)],
+    [Color(0xFF0F3460), Color(0xFF0B1A33)],
+    [Color(0xFF047857), Color(0xFF065F46)],
+    [Color(0xFF1F2937), Color(0xFF111827)],
+  ];
+
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -36,42 +45,84 @@ class AccountsSecondCard extends StatelessWidget {
           .fold<double>(0, (p, e) => p + e.amount);
     }
 
-    return Obx(() {
-      final totalParties = partyController.parties.length.toDouble();
-      final depositThisMonth = sumWhereMonth('Deposit');
-      final expenseThisMonth =
-          sumWhereMonth('Expense') + sumWhereMonth('Withdrawal');
-      final totalDeposit = sumWhere('Deposit');
-      final totalExpense = sumWhere('Expense') + sumWhere('Withdrawal');
-      final balance = totalDeposit - totalExpense;
+    return Material(
+      color: cs.surface,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            const spacing = 16.0;
+            final width = constraints.maxWidth;
+            final crossAxisCount = width >= 900
+                ? 3
+                : width >= 520
+                    ? 2
+                    : 1;
+            final availableWidth =
+                width - spacing * (crossAxisCount - 1);
+            final cardWidth = availableWidth / crossAxisCount;
 
-      return Material(
-        color: cs.surface,
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: Column(
-            spacing: 5,
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            return Obx(() {
+              final totalParties = partyController.parties.length.toDouble();
+              final depositThisMonth = sumWhereMonth('Deposit');
+              final expenseThisMonth =
+                  sumWhereMonth('Expense') + sumWhereMonth('Withdrawal');
+              final totalDeposit = sumWhere('Deposit');
+              final totalExpense = sumWhere('Expense') + sumWhere('Withdrawal');
+              final balance = totalDeposit - totalExpense;
+
+              return Wrap(
+                spacing: spacing,
+                runSpacing: spacing,
                 children: [
-                  AccountsCard(title: 'মোট পার্টি', amount: totalParties),
-                  AccountsCard(title: 'এই মাসে জমা', amount: depositThisMonth),
-                  AccountsCard(title: 'এই মাসে খরচ', amount: expenseThisMonth),
+                  AccountsCard(
+                    title: 'মোট পার্টি',
+                    amount: totalParties,
+                    icon: Icons.groups_rounded,
+                    gradientColors: _gradients[0],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'এই মাসে জমা',
+                    amount: depositThisMonth,
+                    icon: Icons.savings_rounded,
+                    gradientColors: _gradients[1],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'এই মাসে খরচ',
+                    amount: expenseThisMonth,
+                    icon: Icons.trending_down,
+                    gradientColors: _gradients[2],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'মোট জমা',
+                    amount: totalDeposit,
+                    icon: Icons.account_balance_wallet_rounded,
+                    gradientColors: _gradients[3],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'মোট খরচ',
+                    amount: totalExpense,
+                    icon: Icons.receipt_long,
+                    gradientColors: _gradients[4],
+                    width: cardWidth,
+                  ),
+                  AccountsCard(
+                    title: 'বর্তমান ব্যালেন্স',
+                    amount: balance,
+                    icon: Icons.account_balance,
+                    gradientColors: _gradients[5],
+                    width: cardWidth,
+                  ),
                 ],
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  AccountsCard(title: 'মোট জমা', amount: totalDeposit),
-                  AccountsCard(title: 'মোট খরচ', amount: totalExpense),
-                  AccountsCard(title: 'বর্তমান ব্যালেন্স', amount: balance),
-                ],
-              ),
-            ],
-          ),
+              );
+            });
+          },
         ),
-      );
-    });
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- redesign the reusable account card to include gradient backgrounds, status icons, and bolder typography
- replace the dashboard rows with responsive wraps that feed icons and gradient palettes into the new cards for cases and accounts data

## Testing
- Not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8f4ebaaa48330be0ac46b3e379334