### PR TITLE
Set light theme as default

### DIFF
--- a/lib/themes/theme_controller.dart
+++ b/lib/themes/theme_controller.dart
@@ -4,7 +4,7 @@ import 'package:get/get.dart';
 import '../services/local_storage.dart';
 
 class ThemeController extends GetxController {
-  final _isDarkMode = true.obs; // default to dark mode
+  final _isDarkMode = false.obs; // default to light mode
 
   /// Getter for current theme mode.
   bool get isDarkMode => _isDarkMode.value;
@@ -27,6 +27,6 @@ class ThemeController extends GetxController {
   /// Load theme from storage.
   void _loadTheme() {
     bool? storedTheme = LocalStorageService.read("isDarkMode");
-    _isDarkMode.value = storedTheme ?? true; // default to dark if unset
+    _isDarkMode.value = storedTheme ?? false; // default to light if unset
   }
 }


### PR DESCRIPTION
## Summary
- switch the theme controller's initial mode to light
- default stored theme fallback now keeps the app in light mode when unset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ca09358c8330bf3d4b00ebb92a09