### PR TITLE
Normalize activation plan to annual subscription

### DIFF
--- a/lib/modules/court_dairy/screens/account_activation_screen.dart
+++ b/lib/modules/court_dairy/screens/account_activation_screen.dart
@@ -93,17 +93,25 @@ class _ActivationPlanCard extends StatelessWidget {
     final cs = theme.colorScheme;
     final activationCharge = controller.activationCharge;
     final validityDays = controller.activationValidity;
+    final baseCharge = controller.baseActivationCharge;
+    final baseValidity = controller.baseActivationValidity;
 
     String planTitle;
     String feeLabel;
     String durationSummary;
     String accessDescription;
+    String calculationSummary = '';
 
     if (validityDays >= 365) {
       planTitle = 'বার্ষিক অ্যাক্টিভেশন প্যাকেজ';
       feeLabel = 'বার্ষিক ফি';
       durationSummary = 'এক বছর মেয়াদী সাবস্ক্রিপশনের জন্য এককালীন পেমেন্ট।';
       accessDescription = 'পুরো বছরের';
+      if (baseCharge > 0 && baseValidity > 0 &&
+          (baseValidity != validityDays || baseCharge != activationCharge)) {
+        calculationSummary =
+            'ডাটাবেসে নির্ধারিত ${_toBanglaDigits(baseValidity.toString())} দিনের ${_formatAmount(baseCharge)} ফি অনুসারে এক বছরের চার্জ নির্ণয় করা হয়েছে।';
+      }
     } else if (validityDays >= 30) {
       planTitle = 'মাসিক অ্যাক্টিভেশন প্যাকেজ';
       feeLabel = 'মাসিক ফি';
@@ -242,6 +250,16 @@ class _ActivationPlanCard extends StatelessWidget {
                     color: cs.onSurfaceVariant,
                   ),
                 ),
+                if (calculationSummary.isNotEmpty) ...[
+                  const SizedBox(height: 6),
+                  Text(
+                    calculationSummary,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: cs.onSurfaceVariant,
+                      height: 1.45,
+                    ),
+                  ),
+                ],
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- convert activation controller charge calculation to always represent a one-year subscription based on backend configuration
- surface the original backend charge and validity details in the activation screen to explain the derived annual fee

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8d040f3808330adc7e3457e7bd0a4