### PR TITLE
Normalize activation pricing to yearly plan

### DIFF
--- a/lib/modules/court_dairy/screens/account_activation_screen.dart
+++ b/lib/modules/court_dairy/screens/account_activation_screen.dart
@@ -95,6 +95,8 @@ class _ActivationPlanCard extends StatelessWidget {
     final validityDays = controller.activationValidity;
     final baseCharge = controller.baseActivationCharge;
     final baseValidity = controller.baseActivationValidity;
+    final baseValidityMonths = controller.baseActivationValidityMonths;
+    final isBaseValidityMonthly = controller.baseValidityRepresentsMonths;
 
     String planTitle;
     String feeLabel;
@@ -109,8 +111,11 @@ class _ActivationPlanCard extends StatelessWidget {
       accessDescription = 'পুরো বছরের';
       if (baseCharge > 0 && baseValidity > 0 &&
           (baseValidity != validityDays || baseCharge != activationCharge)) {
+        final durationLabel = isBaseValidityMonthly && baseValidityMonths > 0
+            ? '${_toBanglaDigits(baseValidityMonths.toString())} মাসের'
+            : '${_toBanglaDigits(baseValidity.toString())} দিনের';
         calculationSummary =
-            'ডাটাবেসে নির্ধারিত ${_toBanglaDigits(baseValidity.toString())} দিনের ${_formatAmount(baseCharge)} ফি অনুসারে এক বছরের চার্জ নির্ণয় করা হয়েছে।';
+            'ডাটাবেসে নির্ধারিত $durationLabel ${_formatAmount(baseCharge)} ফি অনুসারে এক বছরের চার্জ নির্ণয় করা হয়েছে।';
       }
     } else if (validityDays >= 30) {
       planTitle = 'মাসিক অ্যাক্টিভেশন প্যাকেজ';


### PR DESCRIPTION
## Summary
- normalise configured activation validity so monthly values are treated as 30-day periods before computing the yearly charge
- expose base validity metadata to the activation screen to explain the yearly price derived from the database configuration

## Testing
- not run (Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8d1f848c8833083c340fa13b7fae2