### PR TITLE
Apply discount to activation payment price

### DIFF
--- a/lib/models/app_config.dart
+++ b/lib/models/app_config.dart
@@ -4,6 +4,7 @@ class AppConfig {
   final String smsApiKey;
   final double smsCharge;
   final String smsSenderId;
+  final double discount;
 
   AppConfig({
     required this.activationCharge,
@@ -11,6 +12,7 @@ class AppConfig {
     required this.smsApiKey,
     required this.smsCharge,
     required this.smsSenderId,
+    required this.discount,
   });
 
   factory AppConfig.fromJson(Map<String, dynamic> json) {
@@ -20,6 +22,7 @@ class AppConfig {
       smsApiKey: json['smsApiKey'] ?? '',
       smsCharge: (json['smsCharge'] ?? 0).toDouble(),
       smsSenderId: json['smsSenderId'] ?? '',
+      discount: (json['discount'] ?? 0).toDouble(),
     );
   }
 
@@ -30,6 +33,7 @@ class AppConfig {
       'smsApiKey': smsApiKey,
       'smsCharge': smsCharge,
       'smsSenderId': smsSenderId,
+      'discount': discount,
     };
   }
 }


### PR DESCRIPTION
## Summary
- add a discount field to the app configuration model
- calculate discounted activation pricing and pass the reduced amount to the payment service
- update the activation screen to display discounted totals and discount details when applicable

## Testing
- dart format lib/models/app_config.dart lib/modules/court_dairy/controllers/account_activation_controller.dart lib/modules/court_dairy/screens/account_activation_screen.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d92d7c7883309052769ec578abe1