### PR TITLE
Improve reliability of scheduled daily notifications

### DIFF
--- a/lib/services/app_initializer.dart
+++ b/lib/services/app_initializer.dart
@@ -64,30 +64,9 @@ class AppInitializer {
       );
     } catch (_) {}
     // Daily reminders via alarm-based scheduling
-    unawaited(
-      localNoti
-          .scheduleDailyAtTime(
-            id: 2,
-            title: 'আগামীকালের কেস',
-            body: 'আগামীকালের কেস দেখতে ট্যাপ করুন।',
-            hour: 16,
-            minute: 0,
-            payload: 'tomorrow_cases',
-          )
-          .catchError((_) {}),
-    );
-    unawaited(
-      localNoti
-          .scheduleDailyAtTime(
-            id: 310,
-            title: 'অপারেটিং কেস আপডেট করুন',
-            body: 'অপারেটিং কেস আপডেট করতে ট্যাপ করুন।',
-            hour: 0,
-            minute: 0,
-            payload: 'overdue_cases',
-          )
-          .catchError((_) {}),
-    );
+    try {
+      await localNoti.scheduleGlobalDailyReminders();
+    } catch (_) {}
 
     // Exact-alarm prompt moved to MyApp builder (after UI mounts)
 


### PR DESCRIPTION
## Summary
- centralize the two daily reminder schedules inside the notification service
- detect exact-alarm capability before scheduling and fall back cleanly when permission is missing
- reschedule reminders after the exact-alarm settings prompt and use wall-clock interpretation for daily times

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8db535ef08330b9980015c3039d86