### PR TITLE
Adjust filter chip outline color for light mode visibility

### DIFF
--- a/lib/modules/case/screens/case_screen.dart
+++ b/lib/modules/case/screens/case_screen.dart
@@ -90,8 +90,7 @@ class CaseScreen extends StatelessWidget {
 
 Widget filterChip(
     BuildContext context, String key, String label, CaseController controller) {
-  final appBarColor = Theme.of(context).appBarTheme.backgroundColor ??
-      Theme.of(context).colorScheme.primary;
+  final outlineColor = Theme.of(context).colorScheme.outline;
   final selected = controller.selectedFilter.value == key;
   return Padding(
     padding: const EdgeInsets.symmetric(horizontal: 4),
@@ -102,7 +101,7 @@ Widget filterChip(
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20),
         side: BorderSide(
-          color: selected ? Colors.transparent : appBarColor,
+          color: selected ? Colors.transparent : outlineColor,
         ),
       ),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,


### PR DESCRIPTION
## Summary
- use the theme outline color for case filter chip borders to ensure light mode contrast
- keep the transparent border when chips are selected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8df81a9a88330abe3600562054114