### PR TITLE
Improve case detail card contrast in light mode

### DIFF
--- a/lib/modules/case/screens/case_detail_screen.dart
+++ b/lib/modules/case/screens/case_detail_screen.dart
@@ -37,9 +37,20 @@ class CaseDetailScreen extends StatelessWidget {
     }
 
     Widget section(String title, Widget child) {
+      final isDark = theme.brightness == Brightness.dark;
+      final cardColor = isDark
+          ? theme.colorScheme.surface
+          : theme.colorScheme.surfaceVariant.withOpacity(0.7);
+      final borderColor = theme.colorScheme.outline.withOpacity(isDark ? 0.2 : 0.4);
+
       return SizedBox(
         width: double.infinity,
         child: Card(
+          color: cardColor,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(color: borderColor),
+          ),
           child: Padding(
             padding: const EdgeInsets.all(10),
             child: Column(


### PR DESCRIPTION
## Summary
- adjust the case detail section cards to use a tinted surface color in light mode
- add a subtle border and rounded corners so cards stand out from the background

## Testing
- `flutter analyze` *(fails: Flutter SDK is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d902395ff483309ebfa5d9b00d40ad