### PR TITLE
Add third dashboard accounts card and rebalance metrics

### DIFF
--- a/lib/modules/layout/widgets/accounts_card.dart
+++ b/lib/modules/layout/widgets/accounts_card.dart
@@ -13,7 +13,7 @@ class AccountsCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: Get.width * 0.3,
+      width: Get.width * 0.45,
       child: Material(
         elevation: 0.1,
         borderRadius: BorderRadius.circular(7),

--- a/lib/modules/layout/widgets/accounts_first_card.dart
+++ b/lib/modules/layout/widgets/accounts_first_card.dart
@@ -28,16 +28,6 @@ class AccountsFirstCard extends StatelessWidget {
           .length
           .toDouble();
       final totalCases = cases.length.toDouble();
-      final threeMonthsAgo = DateTime.now().subtract(const Duration(days: 90));
-      final newCases = cases
-          .where((c) => c.filedDate.toDate().isAfter(threeMonthsAgo))
-          .length
-          .toDouble();
-      final totalCourts = cases
-          .map((c) => c.courtName)
-          .toSet()
-          .length
-          .toDouble();
 
       return Material(
         color: themeController.isDarkMode
@@ -45,25 +35,15 @@ class AccountsFirstCard extends StatelessWidget {
             : const Color.fromARGB(255, 241, 238, 238),
         child: Padding(
           padding: const EdgeInsets.all(8),
-          child: Column(
-            spacing: 5,
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            alignment: WrapAlignment.spaceBetween,
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  AccountsCard(title: 'চলমান কেস', amount: running),
-                  AccountsCard(title: 'বন্ধ কেস', amount: closed),
-                  AccountsCard(title: 'কমপ্লিট কেস', amount: complicated),
-                ],
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  AccountsCard(title: 'মোট কেস', amount: totalCases),
-                  AccountsCard(title: 'নতুন কেস', amount: newCases),
-                  AccountsCard(title: 'মোট কোর্ট', amount: totalCourts),
-                ],
-              ),
+              AccountsCard(title: 'চলমান কেস', amount: running),
+              AccountsCard(title: 'বন্ধ কেস', amount: closed),
+              AccountsCard(title: 'কমপ্লিট কেস', amount: complicated),
+              AccountsCard(title: 'মোট কেস', amount: totalCases),
             ],
           ),
         ),

--- a/lib/modules/layout/widgets/accounts_second_card.dart
+++ b/lib/modules/layout/widgets/accounts_second_card.dart
@@ -25,23 +25,8 @@ class AccountsSecondCard extends StatelessWidget {
           .fold<double>(0, (p, e) => p + e.amount);
     }
 
-    double sumWhereMonth(String type) {
-      final now = DateTime.now();
-      return transactionController.transactions
-          .where(
-            (t) =>
-                t.type == type &&
-                t.createdAt.year == now.year &&
-                t.createdAt.month == now.month,
-          )
-          .fold<double>(0, (p, e) => p + e.amount);
-    }
-
     return Obx(() {
       final totalParties = partyController.parties.length.toDouble();
-      final depositThisMonth = sumWhereMonth('Deposit');
-      final expenseThisMonth =
-          sumWhereMonth('Expense') + sumWhereMonth('Withdrawal');
       final totalDeposit = sumWhere('Deposit');
       final totalExpense = sumWhere('Expense') + sumWhere('Withdrawal');
       final balance = totalDeposit - totalExpense;
@@ -52,25 +37,15 @@ class AccountsSecondCard extends StatelessWidget {
             : const Color.fromARGB(255, 241, 238, 238),
         child: Padding(
           padding: const EdgeInsets.all(8),
-          child: Column(
-            spacing: 5,
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            alignment: WrapAlignment.spaceBetween,
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  AccountsCard(title: 'মোট পার্টি', amount: totalParties),
-                  AccountsCard(title: 'এই মাসে জমা', amount: depositThisMonth),
-                  AccountsCard(title: 'এই মাসে খরচ', amount: expenseThisMonth),
-                ],
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  AccountsCard(title: 'মোট জমা', amount: totalDeposit),
-                  AccountsCard(title: 'মোট খরচ', amount: totalExpense),
-                  AccountsCard(title: 'বর্তমান ব্যালেন্স', amount: balance),
-                ],
-              ),
+              AccountsCard(title: 'মোট পার্টি', amount: totalParties),
+              AccountsCard(title: 'মোট জমা', amount: totalDeposit),
+              AccountsCard(title: 'মোট খরচ', amount: totalExpense),
+              AccountsCard(title: 'বর্তমান ব্যালেন্স', amount: balance),
             ],
           ),
         ),

--- a/lib/modules/layout/widgets/accounts_third_card.dart
+++ b/lib/modules/layout/widgets/accounts_third_card.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../themes/theme_controller.dart';
+import '../../accounts/controllers/transaction_controller.dart';
+import '../../case/controllers/case_controller.dart';
+import 'accounts_card.dart';
+
+class AccountsThirdCard extends StatelessWidget {
+  const AccountsThirdCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final themeController = Get.find<ThemeController>();
+    final caseController = Get.find<CaseController>();
+    final transactionController = Get.isRegistered<TransactionController>()
+        ? Get.find<TransactionController>()
+        : Get.put(TransactionController());
+
+    double sumWhereMonth(String type) {
+      final now = DateTime.now();
+      return transactionController.transactions
+          .where(
+            (t) =>
+                t.type == type &&
+                t.createdAt.year == now.year &&
+                t.createdAt.month == now.month,
+          )
+          .fold<double>(0, (p, e) => p + e.amount);
+    }
+
+    return Obx(() {
+      final cases = caseController.cases;
+      final threeMonthsAgo = DateTime.now().subtract(const Duration(days: 90));
+      final newCases = cases
+          .where((c) => c.filedDate.toDate().isAfter(threeMonthsAgo))
+          .length
+          .toDouble();
+      final totalCourts = cases
+          .map((c) => c.courtName)
+          .toSet()
+          .length
+          .toDouble();
+      final depositThisMonth = sumWhereMonth('Deposit');
+      final expenseThisMonth =
+          sumWhereMonth('Expense') + sumWhereMonth('Withdrawal');
+
+      return Material(
+        color: themeController.isDarkMode
+            ? Colors.black
+            : const Color.fromARGB(255, 241, 238, 238),
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            alignment: WrapAlignment.spaceBetween,
+            children: [
+              AccountsCard(title: 'নতুন কেস', amount: newCases),
+              AccountsCard(title: 'মোট কোর্ট', amount: totalCourts),
+              AccountsCard(title: 'এই মাসে জমা', amount: depositThisMonth),
+              AccountsCard(title: 'এই মাসে খরচ', amount: expenseThisMonth),
+            ],
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/lib/modules/layout/widgets/dashboard.dart
+++ b/lib/modules/layout/widgets/dashboard.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:card_swiper/card_swiper.dart';
 import 'accounts_first_card.dart';
 import 'accounts_second_card.dart';
+import 'accounts_third_card.dart';
 import 'app_text.dart';
 
 class Dashboard extends StatelessWidget {
@@ -12,14 +13,15 @@ class Dashboard extends StatelessWidget {
     return Column(
       children: [
         SizedBox(
-          height: 116,
+          height: 170,
           child: Swiper(
-            itemCount: 2,
+            itemCount: 3,
             loop: true,
             autoplay: true,
             itemBuilder: (context, index) {
               if (index == 0) return AccountsFirstCard();
-              return AccountsSecondCard();
+              if (index == 1) return AccountsSecondCard();
+              return AccountsThirdCard();
             },
           ),
         ),


### PR DESCRIPTION
## Summary
- refactor the existing dashboard account cards to present four metrics apiece with a wrap layout
- add a third accounts card that surfaces new case, court count, and monthly transaction totals
- adjust the swiper configuration and shared card sizing to accommodate the additional card

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9078eaae08330bf174228c9fc9a70