### PR TITLE
Revamp dashboard metrics cards

### DIFF
--- a/lib/modules/layout/widgets/accounts_card.dart
+++ b/lib/modules/layout/widgets/accounts_card.dart
@@ -1,46 +1,140 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 import 'package:intl/intl.dart';
-import '../../../themes/theme_controller.dart';
+
+class DashboardMetric {
+  final String title;
+  final double amount;
+  final IconData icon;
+
+  const DashboardMetric({
+    required this.title,
+    required this.amount,
+    required this.icon,
+  });
+}
+
+class DashboardMetricsGrid extends StatelessWidget {
+  final List<DashboardMetric> metrics;
+
+  const DashboardMetricsGrid({super.key, required this.metrics});
+
+  @override
+  Widget build(BuildContext context) {
+    const horizontalPadding = 16.0;
+    const spacing = 16.0;
+    final width = MediaQuery.of(context).size.width;
+    final availableWidth = width - (horizontalPadding * 2);
+    final canShowTwoColumns = availableWidth >= 500;
+    final cardWidth = canShowTwoColumns
+        ? (availableWidth - spacing) / 2
+        : availableWidth;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: horizontalPadding,
+        vertical: 12,
+      ),
+      child: Wrap(
+        spacing: spacing,
+        runSpacing: spacing,
+        children: metrics
+            .map(
+              (metric) => AccountsCard(
+                title: metric.title,
+                amount: metric.amount,
+                icon: metric.icon,
+                cardWidth: cardWidth,
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}
 
 class AccountsCard extends StatelessWidget {
   final String title;
   final double amount;
+  final IconData icon;
+  final double cardWidth;
 
-  AccountsCard({super.key, required this.title, required this.amount});
-  final themeController = Get.find<ThemeController>();
+  const AccountsCard({
+    super.key,
+    required this.title,
+    required this.amount,
+    required this.icon,
+    required this.cardWidth,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final accent = theme.colorScheme.primary;
+    final numberFormatter = NumberFormat.currency(
+      locale: 'bn_BD',
+      symbol: '',
+      decimalDigits: 0,
+    );
+
     return SizedBox(
-      width: Get.width * 0.45,
-      child: Material(
-        elevation: 0.1,
-        borderRadius: BorderRadius.circular(7),
-        color: Theme.of(context).scaffoldBackgroundColor,
-        child: Padding(
-          padding: const EdgeInsets.all(3.0),
-          child: Column(
-            children: [
-              Text(title),
-              TweenAnimationBuilder<int>(
-                tween: IntTween(
-                  begin: 0,
-                  end: amount.floor(),
-                ), // Count up to endValue
-                duration: const Duration(seconds: 1),
-                builder: (context, value, child) {
-                  return Text(
-                    NumberFormat.currency(
-                      locale: 'bn_BD',
-                      symbol: '',
-                      decimalDigits: 0,
-                    ).format(value).trim(), // Format the number as currency
-                  );
-                },
+      width: cardWidth,
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: isDark ? const Color(0xFF1D2331) : Colors.white,
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: accent.withOpacity(0.08)),
+          boxShadow: [
+            BoxShadow(
+              color: isDark
+                  ? Colors.black.withOpacity(0.35)
+                  : Colors.black.withOpacity(0.08),
+              blurRadius: 24,
+              offset: const Offset(0, 12),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: accent.withOpacity(isDark ? 0.18 : 0.12),
+                borderRadius: BorderRadius.circular(16),
               ),
-            ],
-          ),
+              padding: const EdgeInsets.all(12),
+              child: Icon(
+                icon,
+                color: accent,
+                size: 28,
+              ),
+            ),
+            const SizedBox(height: 18),
+            Text(
+              title,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 10),
+            TweenAnimationBuilder<double>(
+              tween: Tween<double>(
+                begin: 0,
+                end: amount,
+              ),
+              duration: const Duration(milliseconds: 600),
+              curve: Curves.easeOutCubic,
+              builder: (context, value, child) {
+                return Text(
+                  numberFormatter.format(value).trim(),
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                );
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/lib/modules/layout/widgets/accounts_first_card.dart
+++ b/lib/modules/layout/widgets/accounts_first_card.dart
@@ -1,7 +1,6 @@
 ﻿import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '../../../themes/theme_controller.dart';
 import '../../case/controllers/case_controller.dart';
 import 'accounts_card.dart';
 
@@ -10,7 +9,6 @@ class AccountsFirstCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final themeController = Get.find<ThemeController>();
     final caseController = Get.find<CaseController>();
 
     return Obx(() {
@@ -29,24 +27,29 @@ class AccountsFirstCard extends StatelessWidget {
           .toDouble();
       final totalCases = cases.length.toDouble();
 
-      return Material(
-        color: themeController.isDarkMode
-            ? Colors.black
-            : const Color.fromARGB(255, 241, 238, 238),
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            alignment: WrapAlignment.spaceBetween,
-            children: [
-              AccountsCard(title: 'চলমান কেস', amount: running),
-              AccountsCard(title: 'বন্ধ কেস', amount: closed),
-              AccountsCard(title: 'কমপ্লিট কেস', amount: complicated),
-              AccountsCard(title: 'মোট কেস', amount: totalCases),
-            ],
+      return DashboardMetricsGrid(
+        metrics: [
+          DashboardMetric(
+            title: 'চলমান কেস',
+            amount: running,
+            icon: Icons.play_circle_fill,
           ),
-        ),
+          DashboardMetric(
+            title: 'বন্ধ কেস',
+            amount: closed,
+            icon: Icons.lock_outline,
+          ),
+          DashboardMetric(
+            title: 'কমপ্লিট কেস',
+            amount: complicated,
+            icon: Icons.task_alt,
+          ),
+          DashboardMetric(
+            title: 'মোট কেস',
+            amount: totalCases,
+            icon: Icons.library_books,
+          ),
+        ],
       );
     });
   }

--- a/lib/modules/layout/widgets/accounts_second_card.dart
+++ b/lib/modules/layout/widgets/accounts_second_card.dart
@@ -1,7 +1,6 @@
 ﻿import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '../../../themes/theme_controller.dart';
 import '../../accounts/controllers/transaction_controller.dart';
 import '../../party/controllers/party_controller.dart';
 import 'accounts_card.dart';
@@ -11,7 +10,6 @@ class AccountsSecondCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final themeController = Get.find<ThemeController>();
     final partyController = Get.isRegistered<PartyController>()
         ? Get.find<PartyController>()
         : Get.put(PartyController());
@@ -31,24 +29,29 @@ class AccountsSecondCard extends StatelessWidget {
       final totalExpense = sumWhere('Expense') + sumWhere('Withdrawal');
       final balance = totalDeposit - totalExpense;
 
-      return Material(
-        color: themeController.isDarkMode
-            ? Colors.black
-            : const Color.fromARGB(255, 241, 238, 238),
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            alignment: WrapAlignment.spaceBetween,
-            children: [
-              AccountsCard(title: 'মোট পার্টি', amount: totalParties),
-              AccountsCard(title: 'মোট জমা', amount: totalDeposit),
-              AccountsCard(title: 'মোট খরচ', amount: totalExpense),
-              AccountsCard(title: 'বর্তমান ব্যালেন্স', amount: balance),
-            ],
+      return DashboardMetricsGrid(
+        metrics: [
+          DashboardMetric(
+            title: 'মোট পার্টি',
+            amount: totalParties,
+            icon: Icons.people_alt,
           ),
-        ),
+          DashboardMetric(
+            title: 'মোট জমা',
+            amount: totalDeposit,
+            icon: Icons.savings,
+          ),
+          DashboardMetric(
+            title: 'মোট খরচ',
+            amount: totalExpense,
+            icon: Icons.trending_down,
+          ),
+          DashboardMetric(
+            title: 'বর্তমান ব্যালেন্স',
+            amount: balance,
+            icon: Icons.account_balance_wallet,
+          ),
+        ],
       );
     });
   }

--- a/lib/modules/layout/widgets/accounts_third_card.dart
+++ b/lib/modules/layout/widgets/accounts_third_card.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '../../../themes/theme_controller.dart';
 import '../../accounts/controllers/transaction_controller.dart';
 import '../../case/controllers/case_controller.dart';
 import 'accounts_card.dart';
@@ -11,7 +10,6 @@ class AccountsThirdCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final themeController = Get.find<ThemeController>();
     final caseController = Get.find<CaseController>();
     final transactionController = Get.isRegistered<TransactionController>()
         ? Get.find<TransactionController>()
@@ -45,24 +43,29 @@ class AccountsThirdCard extends StatelessWidget {
       final expenseThisMonth =
           sumWhereMonth('Expense') + sumWhereMonth('Withdrawal');
 
-      return Material(
-        color: themeController.isDarkMode
-            ? Colors.black
-            : const Color.fromARGB(255, 241, 238, 238),
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            alignment: WrapAlignment.spaceBetween,
-            children: [
-              AccountsCard(title: 'নতুন কেস', amount: newCases),
-              AccountsCard(title: 'মোট কোর্ট', amount: totalCourts),
-              AccountsCard(title: 'এই মাসে জমা', amount: depositThisMonth),
-              AccountsCard(title: 'এই মাসে খরচ', amount: expenseThisMonth),
-            ],
+      return DashboardMetricsGrid(
+        metrics: [
+          DashboardMetric(
+            title: 'নতুন কেস',
+            amount: newCases,
+            icon: Icons.new_releases,
           ),
-        ),
+          DashboardMetric(
+            title: 'মোট কোর্ট',
+            amount: totalCourts,
+            icon: Icons.account_balance,
+          ),
+          DashboardMetric(
+            title: 'এই মাসে জমা',
+            amount: depositThisMonth,
+            icon: Icons.attach_money,
+          ),
+          DashboardMetric(
+            title: 'এই মাসে খরচ',
+            amount: expenseThisMonth,
+            icon: Icons.money_off,
+          ),
+        ],
       );
     });
   }

--- a/lib/modules/layout/widgets/app_text.dart
+++ b/lib/modules/layout/widgets/app_text.dart
@@ -14,59 +14,76 @@ class AppText extends StatelessWidget {
   }
 
   final TextStyle colorizeTextStyle = const TextStyle(
-    fontSize: 14,
-    fontWeight: FontWeight.bold,
+    fontSize: 16,
+    fontWeight: FontWeight.w700,
   );
 
   @override
   Widget build(BuildContext context) {
     final themeController = Get.find<ThemeController>();
 
-    return Padding(
-      padding: const EdgeInsets.all(5.0),
-      child: SizedBox(
-        width: double.infinity,
-        child: Material(
-          color: themeController.isDarkMode
-              ? Colors.black
-              : const Color.fromARGB(255, 241, 238, 238),
-          borderRadius: BorderRadius.circular(8),
+    final isDark = themeController.isDarkMode;
+    final borderColor = Theme.of(context).colorScheme.primary.withOpacity(0.16);
 
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Center(
-              child: AnimatedTextKit(
-                animatedTexts: [
-                  ColorizeAnimatedText(
-                    'কোর্ট ডাইরি অ্যাপ ব্যবহার খুব সহজ ও নিরাপদ',
-                    textStyle: colorizeTextStyle,
-                    colors: _colors(context),
-                    textAlign: TextAlign.center,
-                  ),
-                  ColorizeAnimatedText(
-                    'অটমেটিক ডাটা বেকাপ থাকে Google সার্ভারে',
-                    textStyle: colorizeTextStyle,
-                    colors: _colors(context),
-                    textAlign: TextAlign.center,
-                  ),
-                  ColorizeAnimatedText(
-                    'ইন্টারনেট ছাড়াও ব্যবহার করুন নিশ্চিন্তে',
-                    textStyle: colorizeTextStyle,
-                    colors: _colors(context),
-                    textAlign: TextAlign.center,
-                  ),
-                  ColorizeAnimatedText(
-                    'কোন ধরণের এড বা বিজ্ঞাপন দেখার ঝামেলা নেই',
-                    textStyle: colorizeTextStyle,
-                    colors: _colors(context),
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-                isRepeatingAnimation: true,
-                repeatForever: true,
-                stopPauseOnTap: true,
-              ),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(28),
+          gradient: LinearGradient(
+            colors: isDark
+                ? const [Color(0xFF161B2C), Color(0xFF101320)]
+                : [
+                    Theme.of(context).colorScheme.primary.withOpacity(0.18),
+                    Theme.of(context).colorScheme.secondary.withOpacity(0.12),
+                  ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          border: Border.all(color: borderColor),
+          boxShadow: [
+            BoxShadow(
+              color: isDark
+                  ? Colors.black.withOpacity(0.35)
+                  : Theme.of(context).colorScheme.primary.withOpacity(0.12),
+              blurRadius: 28,
+              offset: const Offset(0, 18),
             ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 22),
+          child: AnimatedTextKit(
+            animatedTexts: [
+              ColorizeAnimatedText(
+                'কোর্ট ডাইরি অ্যাপ ব্যবহার খুব সহজ ও নিরাপদ',
+                textStyle: colorizeTextStyle,
+                colors: _colors(context),
+                textAlign: TextAlign.center,
+              ),
+              ColorizeAnimatedText(
+                'অটমেটিক ডাটা বেকাপ থাকে Google সার্ভারে',
+                textStyle: colorizeTextStyle,
+                colors: _colors(context),
+                textAlign: TextAlign.center,
+              ),
+              ColorizeAnimatedText(
+                'ইন্টারনেট ছাড়াও ব্যবহার করুন নিশ্চিন্তে',
+                textStyle: colorizeTextStyle,
+                colors: _colors(context),
+                textAlign: TextAlign.center,
+              ),
+              ColorizeAnimatedText(
+                'কোন ধরণের এড বা বিজ্ঞাপন দেখার ঝামেলা নেই',
+                textStyle: colorizeTextStyle,
+                colors: _colors(context),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            pause: const Duration(milliseconds: 800),
+            isRepeatingAnimation: true,
+            repeatForever: true,
+            stopPauseOnTap: true,
           ),
         ),
       ),

--- a/lib/modules/layout/widgets/dashboard.dart
+++ b/lib/modules/layout/widgets/dashboard.dart
@@ -10,22 +10,71 @@ class Dashboard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    Widget buildCarouselCard(Widget child) {
+      return Container(
+        margin: const EdgeInsets.symmetric(vertical: 8),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(28),
+          gradient: LinearGradient(
+            colors: isDark
+                ? const [Color(0xFF151A2B), Color(0xFF10131F)]
+                : const [Color(0xFFEFF3FF), Color(0xFFF9FBFF)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: isDark
+                  ? Colors.black.withOpacity(0.45)
+                  : Colors.black.withOpacity(0.08),
+              blurRadius: 26,
+              offset: const Offset(0, 16),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(28),
+          child: child,
+        ),
+      );
+    }
+
     return Column(
       children: [
-        SizedBox(
-          height: 115,
-          child: Swiper(
-            itemCount: 3,
-            loop: true,
-            autoplay: true,
-            itemBuilder: (context, index) {
-              if (index == 0) return AccountsFirstCard();
-              if (index == 1) return AccountsSecondCard();
-              return AccountsThirdCard();
-            },
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+          child: SizedBox(
+            height: 360,
+            child: Swiper(
+              itemCount: 3,
+              loop: true,
+              autoplay: true,
+              viewportFraction: 0.94,
+              scale: 0.98,
+              pagination: SwiperPagination(
+                builder: DotSwiperPaginationBuilder(
+                  size: 6,
+                  activeSize: 10,
+                  color: theme.colorScheme.primary.withOpacity(0.2),
+                  activeColor: theme.colorScheme.primary,
+                ),
+              ),
+              itemBuilder: (context, index) {
+                if (index == 0) {
+                  return buildCarouselCard(AccountsFirstCard());
+                }
+                if (index == 1) {
+                  return buildCarouselCard(AccountsSecondCard());
+                }
+                return buildCarouselCard(AccountsThirdCard());
+              },
+            ),
           ),
         ),
-        AppText(),
+        const AppText(),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- redesign the dashboard carousel to present metrics in card-style slides with themed pagination
- introduce reusable metric grid and icon-enhanced cards for case, party, and finance stats
- refresh the announcement banner styling to match the updated dashboard aesthetics

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d90e4c9c688330aa77f1d6819a34bb